### PR TITLE
Doubling the points to make it a bit more fair

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -39,11 +39,11 @@ export default {
   data: function () {
     return {
       points: [
-        5000,
+        10000,
+        2000,
         1000,
-        500,
-        100,
-        25
+        200,
+        50
       ]
     }
   },


### PR DESCRIPTION
Ik heb dit spel nu al een paar keer gespeeld, en ik vind het erg leuk, maar de conversie van het aantal meters dat je er naast zit naar de sterren voelt een beetje oneerlijk naar mijn mening. Voor 171 meter krijg je drie sterren, voor iets meer dan een kilometer één ster. Dan wordt het wel echt heel tricky om vier of vijf sterren te halen. Ik heb daarom de punten verdubbeld in deze commit.